### PR TITLE
Update 'stretch' installer to Debian 9.4

### DIFF
--- a/classes/os/debian_stretch_files.yml
+++ b/classes/os/debian_stretch_files.yml
@@ -3,20 +3,20 @@ parameters:
     debian:
       stretch:
         amd64:
-          - url: 'http://ftp.uni-stuttgart.de/debian/dists/Debian9.0/main/installer-amd64/current/images/MANIFEST'
+          - url: 'http://ftp.uni-stuttgart.de/debian/dists/Debian9.4/main/installer-amd64/current/images/MANIFEST'
             dest: '{{ os__tmp_images_dir }}/MANIFEST'
             checksum: 'sha256:82f69d557f0004d2923fb03e4fb47d18187e37768dbfd0c99756f8a6c68a6d3a'
             virt_install: True
-          - url: 'http://ftp.uni-stuttgart.de/debian/dists/Debian9.0/main/installer-amd64/current/images/MANIFEST.udebs'
+          - url: 'http://ftp.uni-stuttgart.de/debian/dists/Debian9.4/main/installer-amd64/current/images/MANIFEST.udebs'
             dest: '{{ os__tmp_images_dir }}/MANIFEST.udeps'
-            checksum: 'sha256:f5c88efd2ad926f032199c0bfd37fcd612487b7c27a1b5d1608ba71c43fd16bf'
+            checksum: 'sha256:b3fab1de2a01feeaacf55fbf9549166fed27c30312cc20652cf11df63943bdd0'
             virt_install: True
-          - url: 'http://ftp.uni-stuttgart.de/debian/dists/Debian9.0/main/installer-amd64/current/images/netboot/debian-installer/amd64/initrd.gz'
+          - url: 'http://ftp.uni-stuttgart.de/debian/dists/Debian9.4/main/installer-amd64/current/images/netboot/debian-installer/amd64/initrd.gz'
             dest: '{{ os__tmp_image_dir }}/initrd.gz'
-            checksum: 'sha256:adc484c5c039e7b4969c3bc6983950ed06b23ba4796e304cd7207f08ae402b0d'
+            checksum: 'sha256:362be3860fc427b3fe81071741d56863b37a8fc05e3126142559782a9b9d0749'
             virt_install: True
-          - url: 'http://ftp.uni-stuttgart.de/debian/dists/Debian9.0/main/installer-amd64/current/images/netboot/debian-installer/amd64/linux'
+          - url: 'http://ftp.uni-stuttgart.de/debian/dists/Debian9.4/main/installer-amd64/current/images/netboot/debian-installer/amd64/linux'
             dest: '{{ os__tmp_image_dir }}/linux'
-            checksum: 'sha256:30cd32eee8e3a7182b06789a8d6ca39d2aa8cddeaadbe8990427efa0ebb843ab'
+            checksum: 'sha256:bea409469a665a930954c7ee1bbaa77964357988163d83a50ff741d1bbba0811'
             virt_install: True
 


### PR DESCRIPTION
Trying to access the `Debian9.0` URL results in a HTTP 404 error.