### PR TITLE
Add sub-class for CentOS 7 and add proper release and version

### DIFF
--- a/classes/os/centos.yml
+++ b/classes/os/centos.yml
@@ -1,4 +1,4 @@
 parameters:
-  os__type: GNU/Linux
-  os__distro: centos
+  os__type: 'GNU/Linux'
+  os__distro: 'centos'
 

--- a/classes/os/centos_7.yml
+++ b/classes/os/centos_7.yml
@@ -1,0 +1,9 @@
+classes:
+  - os.centos
+
+parameters:
+  os__codename: 7
+  os__version: 7
+
+  # Make sure we always use Python 2
+  ansible_python_interpreter: /usr/bin/python


### PR DESCRIPTION
This finally results in the CentOS hosts being properly listed in maestro's node list